### PR TITLE
fix(ci): migrate sr v4 to v7 for artifact and input support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,19 +54,21 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - uses: urmzd/sr@v4
+      - name: Build release binaries
+        run: |
+          mkdir -p bin
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            GOOS=${target%/*}
+            GOARCH=${target#*/}
+            output="bin/zigbee-skill-${GOOS}-${GOARCH}"
+            GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -o "$output" ./cmd/zigbee-skill
+          done
+
+      - uses: urmzd/sr@v7
         id: sr
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           force: ${{ inputs.force || false }}
-          build-command: |
-            mkdir -p bin
-            for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
-              GOOS=${target%/*}
-              GOARCH=${target#*/}
-              output="bin/zigbee-skill-${GOOS}-${GOARCH}"
-              GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -o "$output" ./cmd/zigbee-skill
-            done
           artifacts: "bin/*"
 
     outputs:

--- a/sr.yaml
+++ b/sr.yaml
@@ -1,37 +1,60 @@
-# sr v4 configuration
+# sr v7 configuration
 # Reference: https://github.com/urmzd/sr#configuration
 
-commit:
-  pattern: ^(?P<type>\w+)(?:\((?P<scope>[^)]+)\))?(?P<breaking>!)?:\s+(?P<description>.+)
-  breaking_section: Breaking Changes
-  misc_section: Miscellaneous
-  types:
-  - name: feat
-    bump: minor
-    section: Features
-  - name: fix
-    bump: patch
-    section: Bug Fixes
-  - name: perf
-    bump: patch
-    section: Performance
-  - name: docs
-    section: Documentation
-  - name: refactor
-    bump: patch
-    section: Refactoring
-  - name: revert
-    section: Reverts
-  - name: chore
-  - name: ci
-  - name: test
-  - name: build
-  - name: style
-release:
-  branches:
-  - main
+git:
   tag_prefix: v
-  changelog:
-    file: CHANGELOG.md
-  version_files: []
-  floating_tags: true
+  floating_tag: true
+
+commit:
+  types:
+    minor:
+      - feat
+    patch:
+      - fix
+      - perf
+      - refactor
+    none:
+      - docs
+      - revert
+      - chore
+      - ci
+      - test
+      - build
+      - style
+
+changelog:
+  file: CHANGELOG.md
+  groups:
+    - name: breaking
+      content:
+        - breaking
+    - name: features
+      content:
+        - feat
+    - name: bug-fixes
+      content:
+        - fix
+    - name: performance
+      content:
+        - perf
+    - name: refactoring
+      content:
+        - refactor
+    - name: misc
+      content:
+        - docs
+        - revert
+        - chore
+        - ci
+        - test
+        - build
+        - style
+
+channels:
+  default: stable
+  branch: main
+  content:
+    - name: stable
+
+packages:
+  - path: .


### PR DESCRIPTION
## Summary
- sr v4 silently ignores `artifacts` and `force` action inputs, so release binaries are not attached to GitHub releases
- Upgrades action from `urmzd/sr@v4` to `urmzd/sr@v7`
- Migrates `sr.yaml` from v4 to v7 config format (grouped commit types, top-level `changelog`/`channels`/`packages` sections)

## Test plan
- [ ] Merge and verify next release attaches binaries (if applicable)
- [ ] Verify `force` input works on `workflow_dispatch`