### PR TITLE
refactor: replace embed-src references with fsrc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,19 +15,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  embed-src:
-    name: Embed-src
+  fsrc:
+    name: fsrc
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: urmzd/embed-src@v3
+      - uses: urmzd/fsrc@v4
         with:
           commit-message: "chore: sync embedded files [skip ci]"
 
   ci:
-    needs: embed-src
+    needs: fsrc
     uses: ./.github/workflows/ci.yml
 
   release:

--- a/README.md
+++ b/README.md
@@ -226,10 +226,10 @@ This project implements the Zigbee PRO stack. The relevant specs are available (
 
 ## Supported Devices
 
-<!-- embed-src src="docs/supported-devices.md" -->
+<!-- fsrc src="docs/supported-devices.md" -->
 | Manufacturer | Model | Model ID | Type | Clusters | Notes |
 |---|---|---|---|---|---|
 | Third Reality | Smart Plug Gen2 | 3RSP019BZ | switch | On/Off (0x0006) | Ships in BLE mode — hold button 5s to switch to Zigbee. Factory reset: hold 10s. |
 | SONOFF | Zigbee 3.0 USB Dongle Plus | — | coordinator | — | EFR32MG21 based. EZSP protocol. Used as the Zigbee coordinator. |
 | Sylvania | A19 70052 | — | light | On/Off, Level Control | — |
-<!-- /embed-src -->
+<!-- /fsrc -->


### PR DESCRIPTION
## Summary
- Rename embed-src to fsrc in workflow jobs and action references (`urmzd/fsrc@v4`)
- Update README markers from `embed-src` to `fsrc`